### PR TITLE
Moving static Promise functions outside of the Promise class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ ChangeLog
 -------------------------
 
 * Now requires PHP 5.5!
-* Aside from the `Promise:all()` function, there's now also `Promise::race()`.
+* `Promise::all()` is moved to `Promise\all()`.
+* Aside from the `Promise\all()` function, there's now also `Promise\race()`.
+* `Promise\reject()` and `Promise\resolve()` have also been added.
+* Now 100% compatible with the Ecmascript 6 Promise.
 
 
 3.0.0-alpha1 (2015-10-23)

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         },
         "files" : [
             "lib/coroutine.php",
-            "lib/Loop/functions.php"
+            "lib/Loop/functions.php",
+            "lib/Promise/functions.php"
         ]
     },
     "require-dev": {

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -225,79 +225,16 @@ class Promise {
     }
 
     /**
-     * It's possible to send an array of promises to the all method. This
-     * method returns a promise that will be fulfilled, only if all the passed
-     * promises are fulfilled.
+     * Deprecated.
+     *
+     * Please use Sabre\Event\Promise::all
      *
      * @param Promise[] $promises
      * @return Promise
      */
     static function all(array $promises) {
 
-        return new self(function($success, $fail) use ($promises) {
-
-            $successCount = 0;
-            $completeResult = [];
-
-            foreach ($promises as $promiseIndex => $subPromise) {
-
-                $subPromise->then(
-                    function($result) use ($promiseIndex, &$completeResult, &$successCount, $success, $promises) {
-                        $completeResult[$promiseIndex] = $result;
-                        $successCount++;
-                        if ($successCount === count($promises)) {
-                            $success($completeResult);
-                        }
-                        return $result;
-                    }
-                )->error(
-                    function($reason) use ($fail) {
-                        $fail($reason);
-                    }
-                );
-
-            }
-        });
-
-    }
-
-    /**
-     * The race function returns a promise that resolves or rejects as soon as
-     * one of the promises in the argument resolves or rejects.
-     *
-     * The returned promise will resolve or reject with the value or reason of
-     * that first promise.
-     *
-     * @param Promise[] $promises
-     * @return Promise
-     */
-    static function race(array $promises) {
-
-        return new self(function($success, $fail) use ($promises) {
-
-            $alreadyDone = false;
-            foreach ($promises as $promise) {
-
-                $promise->then(
-                    function($result) use ($success, &$alreadyDone) {
-                        if ($alreadyDone) {
-                            return;
-                        }
-                        $alreadyDone = true;
-                        $success($result);
-                    },
-                    function($reason) use ($fail, &$alreadyDone) {
-                        if ($alreadyDone) {
-                            return;
-                        }
-                        $alreadyDone = true;
-                        $fail($reason);
-                    }
-                );
-
-            }
-
-        });
+        return Promise\all($promises);
 
     }
 
@@ -312,7 +249,7 @@ class Promise {
      * @param callable $callBack
      * @return void
      */
-    protected function invokeCallback(Promise $subPromise, callable $callBack = null) {
+    private function invokeCallback(Promise $subPromise, callable $callBack = null) {
 
         Loop\nextTick(function() use ($callBack, $subPromise) {
             if (is_callable($callBack)) {

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -102,16 +102,21 @@ function race(array $promises) {
 /**
  * Returns a Promise that resolves with the given value.
  *
+ * If the value is a promise, the returned promise will attach itself to that
+ * promise and eventually get the same state as the followed promise.
+ *
  * @param mixed $value
  * @return Promise
  */
 function resolve($value) {
 
-    return new Promise(function($resolve, $reject) use ($value) {
-
-        $resolve($value);
-
-    });
+    if ($value instanceof Promise) {
+        return $value->then();
+    } else {
+        $promise = new Promise();
+        $promise->fulfill($value);
+        return $promise;
+    }
 
 }
 
@@ -123,10 +128,8 @@ function resolve($value) {
  */
 function reject($reason) {
 
-    return new Promise(function($resolve, $reject) use ($reason) {
-
-        $reject($reason);
-
-    });
+    $promise = new Promise();
+    $promise->reject($reason);
+    return $promise;
 
 }

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -103,7 +103,7 @@ function race(array $promises) {
  * Returns a Promise that resolves with the given value.
  *
  * @param mixed $value
- * @return Promise 
+ * @return Promise
  */
 function resolve($value) {
 
@@ -119,7 +119,7 @@ function resolve($value) {
  * Returns a Promise that will reject with the given reason.
  *
  * @param mixed $reason
- * @return Promise 
+ * @return Promise
  */
 function reject($reason) {
 

--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Sabre\Event\Promise;
+
+use Sabre\Event\Promise;
+
+/**
+ * This file contains a set of functions that are useful for dealing with the
+ * Promise object.
+ *
+ * @copyright Copyright (C) 2013-2015 fruux GmbH (https://fruux.com/).
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+
+
+/**
+ * This function takes an array of Promises, and returns a Promise that
+ * resolves when all of the given arguments have resolved.
+ *
+ * The returned Promise will resolve with a value that's an array of all the
+ * values the given promises have been resolved with.
+ *
+ * This array will be in the exact same order as the array of input promises.
+ *
+ * If any of the given Promises fails, the returned promise will immidiately
+ * fail with the first Promise that fails, and its reason.
+ *
+ * @param Promise[] $promises
+ * @return Promise
+ */
+function all(array $promises) {
+
+    return new Promise(function($success, $fail) use ($promises) {
+
+        $successCount = 0;
+        $completeResult = [];
+
+        foreach ($promises as $promiseIndex => $subPromise) {
+
+            $subPromise->then(
+                function($result) use ($promiseIndex, &$completeResult, &$successCount, $success, $promises) {
+                    $completeResult[$promiseIndex] = $result;
+                    $successCount++;
+                    if ($successCount === count($promises)) {
+                        $success($completeResult);
+                    }
+                    return $result;
+                }
+            )->error(
+                function($reason) use ($fail) {
+                    $fail($reason);
+                }
+            );
+
+        }
+    });
+
+}
+
+/**
+ * The race function returns a promise that resolves or rejects as soon as
+ * one of the promises in the argument resolves or rejects.
+ *
+ * The returned promise will resolve or reject with the value or reason of
+ * that first promise.
+ *
+ * @param Promise[] $promises
+ * @return Promise
+ */
+function race(array $promises) {
+
+    return new Promise(function($success, $fail) use ($promises) {
+
+        $alreadyDone = false;
+        foreach ($promises as $promise) {
+
+            $promise->then(
+                function($result) use ($success, &$alreadyDone) {
+                    if ($alreadyDone) {
+                        return;
+                    }
+                    $alreadyDone = true;
+                    $success($result);
+                },
+                function($reason) use ($fail, &$alreadyDone) {
+                    if ($alreadyDone) {
+                        return;
+                    }
+                    $alreadyDone = true;
+                    $fail($reason);
+                }
+            );
+
+        }
+
+    });
+
+}
+
+
+/**
+ * Returns a Promise that resolves with the given value.
+ *
+ * @param mixed $value
+ * @return Promise 
+ */
+function resolve($value) {
+
+    return new Promise(function($resolve, $reject) use ($value) {
+
+        $resolve($value);
+
+    });
+
+}
+
+/**
+ * Returns a Promise that will reject with the given reason.
+ *
+ * @param mixed $reason
+ * @return Promise 
+ */
+function reject($reason) {
+
+    return new Promise(function($resolve, $reject) use ($reason) {
+
+        $reject($reason);
+
+    });
+
+}

--- a/tests/Promise/FunctionsTest.php
+++ b/tests/Promise/FunctionsTest.php
@@ -144,6 +144,21 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    /**
+     * @expectedException \Exception
+     */
+    function testResolvePromise() {
+
+        $finalValue = 0;
+
+        $promise = new Promise();
+        $promise->reject(new \Exception('uh oh'));
+
+        $newPromise = resolve($promise);
+        $newPromise->wait();
+
+    }
+
     function testReject() {
 
         $finalValue = 0;

--- a/tests/Promise/FunctionsTest.php
+++ b/tests/Promise/FunctionsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Sabre\Event\Promise;
+
+use Sabre\Event\Loop;
+use Sabre\Event\Promise;
+
+class FunctionsTest extends \PHPUnit_Framework_TestCase {
+
+    function testAll() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise\all([$promise1, $promise2])->then(function($value) use (&$finalValue) {
+
+            $finalValue = $value;
+
+        });
+
+        $promise1->fulfill(1);
+        Loop\run();
+        $this->assertEquals(0, $finalValue);
+
+        $promise2->fulfill(2);
+        Loop\run();
+        $this->assertEquals([1, 2], $finalValue);
+
+    }
+
+    function testAllReject() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise\all([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = 'foo';
+                return 'test';
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->reject(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->reject(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testAllRejectThenResolve() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise\all([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = 'foo';
+                return 'test';
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->reject(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->fulfill(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testRace() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise\race([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->fulfill(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->fulfill(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testRaceReject() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise\race([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->reject(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->reject(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testResolve() {
+
+        $finalValue = 0;
+
+        $promise = resolve(1);
+        $promise->then(function($value) use (&$finalValue) {
+
+            $finalValue = $value;
+
+        });
+
+        $this->assertEquals(0, $finalValue);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testReject() {
+
+        $finalValue = 0;
+
+        $promise = reject(1);
+        $promise->then(function($value) use (&$finalValue) {
+
+            $finalValue = 'im broken';
+
+        }, function($reason) use (&$finalValue) {
+
+            $finalValue = $reason;
+        
+        });
+
+        $this->assertEquals(0, $finalValue);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+
+}

--- a/tests/Promise/PromiseTest.php
+++ b/tests/Promise/PromiseTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Sabre\Event\Promise;
+
+use Sabre\Event\Loop;
+use Sabre\Event\Promise;
+
+class PromiseTest extends \PHPUnit_Framework_TestCase {
+
+    function testSuccess() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+        $promise->fulfill(1);
+
+        $promise->then(function($value) use (&$finalValue) {
+            $finalValue = $value + 2;
+        });
+        Loop\run();
+
+        $this->assertEquals(3, $finalValue);
+
+    }
+
+    function testFail() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+        $promise->reject(1);
+
+        $promise->then(null, function($value) use (&$finalValue) {
+            $finalValue = $value + 2;
+        });
+        Loop\run();
+
+        $this->assertEquals(3, $finalValue);
+
+    }
+
+    function testChain() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+        $promise->fulfill(1);
+
+        $promise->then(function($value) use (&$finalValue) {
+            $finalValue = $value + 2;
+            return $finalValue;
+        })->then(function($value) use (&$finalValue) {
+            $finalValue = $value + 4;
+            return $finalValue;
+        });
+        Loop\run();
+
+        $this->assertEquals(7, $finalValue);
+
+    }
+    function testChainPromise() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+        $promise->fulfill(1);
+
+        $subPromise = new Promise();
+
+        $promise->then(function($value) use ($subPromise) {
+            return $subPromise;
+        })->then(function($value) use (&$finalValue) {
+            $finalValue = $value + 4;
+            return $finalValue;
+        });
+
+        $subPromise->fulfill(2);
+        Loop\run();
+
+        $this->assertEquals(6, $finalValue);
+
+    }
+
+    function testPendingResult() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+
+        $promise->then(function($value) use (&$finalValue) {
+            $finalValue = $value + 2;
+        });
+
+        $promise->fulfill(4);
+        Loop\run();
+
+        $this->assertEquals(6, $finalValue);
+
+    }
+
+    function testPendingFail() {
+
+        $finalValue = 0;
+        $promise = new Promise();
+
+        $promise->then(null, function($value) use (&$finalValue) {
+            $finalValue = $value + 2;
+        });
+
+        $promise->reject(4);
+        Loop\run();
+
+        $this->assertEquals(6, $finalValue);
+
+    }
+
+    function testExecutorSuccess() {
+
+        $promise = (new Promise(function($success, $fail) {
+
+            $success('hi');
+
+        }))->then(function($result) use (&$realResult) {
+
+            $realResult = $result;
+
+        });
+        Loop\run();
+
+        $this->assertEquals('hi', $realResult);
+
+    }
+
+    function testExecutorFail() {
+
+        $promise = (new Promise(function($success, $fail) {
+
+            $fail('hi');
+
+        }))->then(function($result) use (&$realResult) {
+
+            $realResult = 'incorrect';
+
+        }, function($reason) use (&$realResult) {
+
+            $realResult = $reason;
+
+        });
+        Loop\run();
+
+        $this->assertEquals('hi', $realResult);
+
+    }
+
+    /**
+     * @expectedException \Sabre\Event\PromiseAlreadyResolvedException
+     */
+    function testFulfillTwice() {
+
+        $promise = new Promise();
+        $promise->fulfill(1);
+        $promise->fulfill(1);
+
+    }
+
+    /**
+     * @expectedException \Sabre\Event\PromiseAlreadyResolvedException
+     */
+    function testRejectTwice() {
+
+        $promise = new Promise();
+        $promise->reject(1);
+        $promise->reject(1);
+
+    }
+
+    function testFromFailureHandler() {
+
+        $ok = 0;
+        $promise = new Promise();
+        $promise->otherwise(function($reason) {
+
+            $this->assertEquals('foo', $reason);
+            throw new \Exception('hi');
+
+        })->then(function() use (&$ok) {
+
+            $ok = -1;
+
+        }, function() use (&$ok) {
+
+            $ok = 1;
+
+        });
+
+        $this->assertEquals(0, $ok);
+        $promise->reject('foo');
+        Loop\run();
+
+        $this->assertEquals(1, $ok);
+
+    }
+
+    function testAll() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise::all([$promise1, $promise2])->then(function($value) use (&$finalValue) {
+
+            $finalValue = $value;
+
+        });
+
+        $promise1->fulfill(1);
+        Loop\run();
+        $this->assertEquals(0, $finalValue);
+
+        $promise2->fulfill(2);
+        Loop\run();
+        $this->assertEquals([1, 2], $finalValue);
+
+    }
+
+    function testAllReject() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise::all([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = 'foo';
+                return 'test';
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->reject(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->reject(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testAllRejectThenResolve() {
+
+        $promise1 = new Promise();
+        $promise2 = new Promise();
+
+        $finalValue = 0;
+        Promise::all([$promise1, $promise2])->then(
+            function($value) use (&$finalValue) {
+                $finalValue = 'foo';
+                return 'test';
+            },
+            function($value) use (&$finalValue) {
+                $finalValue = $value;
+            }
+        );
+
+        $promise1->reject(1);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+        $promise2->fulfill(2);
+        Loop\run();
+        $this->assertEquals(1, $finalValue);
+
+    }
+
+    function testWaitResolve() {
+
+        $promise = new Promise();
+        Loop\nextTick(function() use ($promise) {
+            $promise->fulfill(1);
+        });
+        $this->assertEquals(
+            1,
+            $promise->wait()
+        );
+
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    function testWaitWillNeverResolve() {
+
+        $promise = new Promise();
+        $promise->wait();
+
+    }
+
+    function testWaitRejectedException() {
+
+        $promise = new Promise();
+        Loop\nextTick(function() use ($promise) {
+            $promise->reject(new \OutOfBoundsException('foo'));
+        });
+        try {
+            $promise->wait();
+            $this->fail('We did not get the expected exception');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('OutOfBoundsException', $e);
+            $this->assertEquals('foo', $e->getMessage());
+        }
+
+    }
+
+    function testWaitRejectedScalar() {
+
+        $promise = new Promise();
+        Loop\nextTick(function() use ($promise) {
+            $promise->reject('foo');
+        });
+        try {
+            $promise->wait();
+            $this->fail('We did not get the expected exception');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Exception', $e);
+            $this->assertEquals('foo', $e->getMessage());
+        }
+
+    }
+
+    function testWaitRejectedNonScalar() {
+
+        $promise = new Promise();
+        Loop\nextTick(function() use ($promise) {
+            $promise->reject([]);
+        });
+        try {
+            $promise->wait();
+            $this->fail('We did not get the expected exception');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Exception', $e);
+            $this->assertEquals('Promise was rejected with reason of type: array', $e->getMessage());
+        }
+
+    }
+}

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -271,7 +271,7 @@ class PromiseTest extends \PHPUnit_Framework_TestCase {
         $promise2 = new Promise();
 
         $finalValue = 0;
-        Promise::race([$promise1, $promise2])->then(
+        Promise\race([$promise1, $promise2])->then(
             function($value) use (&$finalValue) {
                 $finalValue = $value;
             },
@@ -295,7 +295,7 @@ class PromiseTest extends \PHPUnit_Framework_TestCase {
         $promise2 = new Promise();
 
         $finalValue = 0;
-        Promise::race([$promise1, $promise2])->then(
+        Promise\race([$promise1, $promise2])->then(
             function($value) use (&$finalValue) {
                 $finalValue = $value;
             },


### PR DESCRIPTION
This PR:

1. Moves  `Promise::all` to `Promise\all`.
2. Moves  `Promise::race` to `Promise\race`.
3. Adds `Promise\resolve` and `Promise\reject`

This PR makes our Promise object 100% in line with the javascript Promise object.