### PR TITLE
Added wildcard and multi-event support to EventEmitter component

### DIFF
--- a/lib/EventEmitterInterface.php
+++ b/lib/EventEmitterInterface.php
@@ -17,12 +17,12 @@ interface EventEmitterInterface {
     /**
      * Subscribe to an event.
      *
-     * @param string $eventName
+     * @param string|string[] $eventNames
      * @param callable $callBack
      * @param int $priority
      * @return void
      */
-    function on($eventName, callable $callBack, $priority = 100);
+    function on($eventNames, callable $callBack, $priority = 100);
 
     /**
      * Subscribe to an event exactly once.
@@ -79,11 +79,11 @@ interface EventEmitterInterface {
      * If the listener could not be found, this method will return false. If it
      * was removed it will return true.
      *
-     * @param string $eventName
+     * @param string|string[] $eventNames
      * @param callable $listener
      * @return bool
      */
-    function removeListener($eventName, callable $listener);
+    function removeListener($eventNames, callable $listener);
 
     /**
      * Removes all listeners.
@@ -92,9 +92,9 @@ interface EventEmitterInterface {
      * removed. If it is not specified, every listener for every event is
      * removed.
      *
-     * @param string $eventName
+     * @param string|string[] $eventNames
      * @return void
      */
-    function removeAllListeners($eventName = null);
+    function removeAllListeners($eventNames = []);
 
 }

--- a/lib/EventEmitterTrait.php
+++ b/lib/EventEmitterTrait.php
@@ -144,21 +144,26 @@ trait EventEmitterTrait {
      */
     function listeners($eventName) {
 
-        if (!isset($this->listeners[$eventName])) {
-            return [];
+        $priorities = [];
+        $callbacks = [];
+
+        $parts = explode(".", $eventName);
+
+        while ($eventName) {
+            if (isset($this->listeners[$eventName])) {
+                $priorities = array_merge($priorities, $this->listeners[$eventName][1]);
+                $callbacks = array_merge($callbacks, $this->listeners[$eventName][2]);
+            }
+            if (array_pop($parts)) {
+                $eventName = implode(".", $parts) . ".*";
+            } else {
+                $eventName = false;
+            }
         }
 
-        // The list is not sorted
-        if (!$this->listeners[$eventName][0]) {
+        array_multisort($priorities, SORT_NUMERIC, $callbacks);
 
-            // Sorting
-            array_multisort($this->listeners[$eventName][1], SORT_NUMERIC, $this->listeners[$eventName][2]);
-
-            // Marking the listeners as sorted
-            $this->listeners[$eventName][0] = true;
-        }
-
-        return $this->listeners[$eventName][2];
+        return $callbacks;
 
     }
 

--- a/lib/EventEmitterTrait.php
+++ b/lib/EventEmitterTrait.php
@@ -139,6 +139,9 @@ trait EventEmitterTrait {
      * The list is returned as an array, and the list of events are sorted by
      * their priority.
      *
+     * If any wildcard listeners match the event, they are also returned. For example,
+     * "foo.bar.baz" is matched by "foo.bar.baz", "foo.bar.*", "foo.*" and "*"
+     *
      * @param string $eventName
      * @return callable[]
      */
@@ -149,15 +152,20 @@ trait EventEmitterTrait {
 
         $parts = explode(".", $eventName);
 
-        while ($eventName) {
+        while (true) {
             if (isset($this->listeners[$eventName])) {
                 $priorities = array_merge($priorities, $this->listeners[$eventName][1]);
                 $callbacks = array_merge($callbacks, $this->listeners[$eventName][2]);
             }
-            if (array_pop($parts)) {
-                $eventName = implode(".", $parts) . ".*";
+
+            if (!array_pop($parts)) {
+                break;
+            }
+
+            if (count($parts)) {
+                $eventName = implode('.', $parts) . '.*';
             } else {
-                $eventName = false;
+                $eventName = '*';
             }
         }
 

--- a/lib/EventEmitterTrait.php
+++ b/lib/EventEmitterTrait.php
@@ -187,23 +187,38 @@ trait EventEmitterTrait {
      * If the listener could not be found, this method will return false. If it
      * was removed it will return true.
      *
-     * @param string $eventName
+     * When unregistering multiple events at once, true will be returned if at least
+     * one of the events was associated with the listener
+     *
+     * @param string|string[] $eventNames
      * @param callable $listener
      * @return bool
      */
-    function removeListener($eventName, callable $listener) {
+    function removeListener($eventNames, callable $listener) {
 
-        if (!isset($this->listeners[$eventName])) {
-            return false;
+        if (!is_array($eventNames)) {
+            $eventNames = [$eventNames];
         }
-        foreach ($this->listeners[$eventName][2] as $index => $check) {
-            if ($check === $listener) {
-                unset($this->listeners[$eventName][1][$index]);
-                unset($this->listeners[$eventName][2][$index]);
-                return true;
+
+        $return = false;
+
+        foreach ($eventNames as $eventName) {
+            if (!isset($this->listeners[$eventName])) {
+                continue;
+            }
+
+            foreach ($this->listeners[$eventName][2] as $index => $check) {
+                if ($check === $listener) {
+                    unset($this->listeners[$eventName][1][$index]);
+                    unset($this->listeners[$eventName][2][$index]);
+
+                    $return = true;
+                    continue; // continue only this foreach
+                }
             }
         }
-        return false;
+
+        return $return;
 
     }
 

--- a/lib/EventEmitterTrait.php
+++ b/lib/EventEmitterTrait.php
@@ -27,23 +27,29 @@ trait EventEmitterTrait {
     /**
      * Subscribe to an event.
      *
-     * @param string $eventName
+     * @param string|string[] $eventNames
      * @param callable $callBack
      * @param int $priority
      * @return void
      */
-    function on($eventName, callable $callBack, $priority = 100) {
+    function on($eventNames, callable $callBack, $priority = 100) {
 
-        if (!isset($this->listeners[$eventName])) {
-            $this->listeners[$eventName] = [
-                true,  // If there's only one item, it's sorted
-                [$priority],
-                [$callBack]
-            ];
-        } else {
-            $this->listeners[$eventName][0] = false; // marked as unsorted
-            $this->listeners[$eventName][1][] = $priority;
-            $this->listeners[$eventName][2][] = $callBack;
+        if (!is_array($eventNames)) {
+            $eventNames = [$eventNames];
+        }
+
+        foreach ($eventNames as $eventName) {
+            if (!isset($this->listeners[$eventName])) {
+                $this->listeners[$eventName] = [
+                    true,  // If there's only one item, it's sorted
+                    [$priority],
+                    [$callBack]
+                ];
+            } else {
+                $this->listeners[$eventName][0] = false; // marked as unsorted
+                $this->listeners[$eventName][1][] = $priority;
+                $this->listeners[$eventName][2][] = $callBack;
+            }
         }
 
     }

--- a/lib/EventEmitterTrait.php
+++ b/lib/EventEmitterTrait.php
@@ -229,13 +229,19 @@ trait EventEmitterTrait {
      * removed. If it is not specified, every listener for every event is
      * removed.
      *
-     * @param string $eventName
+     * @param string|string[] $eventNames
      * @return void
      */
-    function removeAllListeners($eventName = null) {
+    function removeAllListeners($eventNames = []) {
 
-        if (!is_null($eventName)) {
-            unset($this->listeners[$eventName]);
+        if (is_string($eventNames)) {
+            $eventNames = [$eventNames];
+        }
+
+        if (count($eventNames)) {
+            foreach ($eventNames as $eventName) {
+                unset($this->listeners[$eventName]);
+            }
         } else {
             $this->listeners = [];
         }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -326,10 +326,10 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee = new EventEmitter();
 
-        $ee->on("foo", $callback);
-        $ee->on("foo", $callback);
+        $ee->on('foo', $callback);
+        $ee->on('foo', $callback);
 
-        $ee->emit("foo");
+        $ee->emit('foo');
         $this->assertEquals(2, $argResult);
 
     }
@@ -338,13 +338,13 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee = new EventEmitter();
 
-        $callback1 = function () {};
-        $callback2 = function () {};
-        $callback3 = function () {};
+        $callback1 = function() {};
+        $callback2 = function() {};
+        $callback3 = function() {};
 
-        $ee->on("foo.*", $callback1);
-        $ee->on("foo.bar", $callback2);
-        $ee->on("foo.qux", $callback3);
+        $ee->on('foo.*', $callback1);
+        $ee->on('foo.bar', $callback2);
+        $ee->on('foo.qux', $callback3);
 
         $this->assertEquals([$callback1, $callback2], $ee->listeners("foo.bar"));
 
@@ -356,19 +356,41 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee = new EventEmitter();
 
-        $ee->on("foo.*", function() use (&$argResult) {
+        $ee->on('foo.*', function() use (&$argResult) {
             $argResult++;
         });
 
-        $ee->on("foo.bar", function() use (&$argResult) {
+        $ee->on('foo.bar', function() use (&$argResult) {
             $argResult++;
         });
 
-        $ee->emit("foo.bar");
-        $ee->emit("foo.bar");
-        $ee->emit("foo.norf");
+        $ee->emit('foo.bar');
+        $ee->emit('foo.bar');
+        $ee->emit('foo.norf');
 
         $this->assertEquals(5, $argResult);
+
+    }
+
+    function testWildcardListenersRespectPriority() {
+
+        $result = [];
+        $ee = new EventEmitter();
+
+        $ee->on('foo.*', function() use (&$result) {
+            $result[] = 'a';
+        }, 30);
+
+        $ee->on('foo.bar', function() use (&$result) {
+            $result[] = 'b';
+        }, 10);
+
+        $ee->on('foo.bar', function() use (&$result) {
+            $result[] = 'c';
+        }, 20);
+
+        $ee->emit('foo.bar');
+        $this->assertEquals(['b', 'c', 'a'], $result);
 
     }
 

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -315,4 +315,61 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $argResult);
 
     }
+
+    function testRegisterSameListenerTwice() {
+
+        $argResult = 0;
+
+        $callback = function () use (&$argResult) {
+            $argResult++;
+        };
+
+        $ee = new EventEmitter();
+
+        $ee->on("foo", $callback);
+        $ee->on("foo", $callback);
+
+        $ee->emit("foo");
+        $this->assertEquals(2, $argResult);
+
+    }
+
+    function testWildcardListeners() {
+
+        $ee = new EventEmitter();
+
+        $callback1 = function () {};
+        $callback2 = function () {};
+        $callback3 = function () {};
+
+        $ee->on("foo.*", $callback1);
+        $ee->on("foo.bar", $callback2);
+        $ee->on("foo.qux", $callback3);
+
+        $this->assertEquals([$callback1, $callback2], $ee->listeners("foo.bar"));
+
+    }
+
+    function testWildcardCalls() {
+
+        $argResult = 0;
+
+        $ee = new EventEmitter();
+
+        $ee->on("foo.*", function() use (&$argResult) {
+            $argResult++;
+        });
+
+        $ee->on("foo.bar", function() use (&$argResult) {
+            $argResult++;
+        });
+
+        $ee->emit("foo.bar");
+        $ee->emit("foo.bar");
+        $ee->emit("foo.norf");
+
+        $this->assertEquals(5, $argResult);
+
+    }
+
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -480,4 +480,30 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testUnregisterAllListenersForMultipleEvents() {
+
+        $a = 0;
+        $b = 0;
+
+        $ee = new EventEmitter();
+
+        $ee->on(['foo', 'bar', 'qux'], function () use (&$a) {
+            $a++;
+        });
+
+        $ee->on(['bar', 'qux'], function () use (&$b) {
+            $b++;
+        });
+
+        $ee->removeAllListeners(['foo', 'bar']);
+
+        $ee->emit('foo');
+        $ee->emit('bar');
+        $ee->emit('qux');
+
+        $this->assertEquals(1, $a);
+        $this->assertEquals(1, $b);
+
+    }
+
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -320,7 +320,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $argResult = 0;
 
-        $callback = function () use (&$argResult) {
+        $callback = function() use (&$argResult) {
             $argResult++;
         };
 
@@ -399,7 +399,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
         $result = false;
 
         $ee = new EventEmitter();
-        $ee->on('*', function () use (&$result) {
+        $ee->on('*', function() use (&$result) {
             $result = true;
         });
 
@@ -417,17 +417,17 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee = new EventEmitter();
 
-        $ee->on('*', function () use (&$fooSpy, &$barSpy, &$quxSpy) {
+        $ee->on('*', function() use (&$fooSpy, &$barSpy, &$quxSpy) {
             $fooSpy++;
             $barSpy++;
             $quxSpy++;
         });
 
-        $ee->on('foo', function () use (&$fooSpy) {
+        $ee->on('foo', function() use (&$fooSpy) {
             $fooSpy++;
         });
 
-        $ee->on('bar', function () use (&$barSpy) {
+        $ee->on('bar', function() use (&$barSpy) {
             $barSpy++;
         });
 
@@ -446,7 +446,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
         $argResult = 0;
         $ee = new EventEmitter();
 
-        $ee->on(['foo', 'bar'], function () use (&$argResult) {
+        $ee->on(['foo', 'bar'], function() use (&$argResult) {
             $argResult++;
         });
 
@@ -462,7 +462,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $argResult = 0;
 
-        $callback = function () use (&$argResult) {
+        $callback = function() use (&$argResult) {
             $argResult++;
         };
 
@@ -487,11 +487,11 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee = new EventEmitter();
 
-        $ee->on(['foo', 'bar', 'qux'], function () use (&$a) {
+        $ee->on(['foo', 'bar', 'qux'], function() use (&$a) {
             $a++;
         });
 
-        $ee->on(['bar', 'qux'], function () use (&$b) {
+        $ee->on(['bar', 'qux'], function() use (&$b) {
             $b++;
         });
 

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -441,5 +441,23 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testRegisterSameListenerForMultipleEventsAtOnce() {
+
+        $argResult = 0;
+        $ee = new EventEmitter();
+
+        $ee->on(['foo', 'bar'], function () use (&$argResult) {
+            $argResult++;
+        });
+
+        $ee->emit('foo');
+        $ee->emit('bar');
+        $ee->emit('qux');
+
+        $this->assertEquals(2, $argResult);
+
+    }
+
+
 
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -441,7 +441,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    function testRegisterSameListenerForMultipleEventsAtOnce() {
+    function testRegisterSameListenerForMultipleEvents() {
 
         $argResult = 0;
         $ee = new EventEmitter();
@@ -458,6 +458,26 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testUnregisterMultipleEvents() {
 
+        $argResult = 0;
+
+        $callback = function () use (&$argResult) {
+            $argResult++;
+        };
+
+        $ee = new EventEmitter();
+
+        $ee->on(['foo', 'bar', 'qux'], $callback);
+
+        $ee->removeListener(['foo', 'bar'], $callback);
+
+        $ee->emit('foo');
+        $ee->emit('bar');
+        $ee->emit('qux');
+
+        $this->assertEquals(1, $argResult);
+
+    }
 
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -366,7 +366,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
 
         $ee->emit('foo.bar');
         $ee->emit('foo.bar');
-        $ee->emit('foo.norf');
+        $ee->emit('foo.qux');
 
         $this->assertEquals(5, $argResult);
 
@@ -393,5 +393,53 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(['b', 'c', 'a'], $result);
 
     }
+
+    function testGlobalWildcard() {
+
+        $result = false;
+
+        $ee = new EventEmitter();
+        $ee->on('*', function () use (&$result) {
+            $result = true;
+        });
+
+        $ee->emit('foo');
+
+        $this->assertTrue($result);
+
+    }
+
+    function testUseWildcardToRegisterGlobalListener() {
+
+        $fooSpy = 0;
+        $barSpy = 0;
+        $quxSpy = 0;
+
+        $ee = new EventEmitter();
+
+        $ee->on('*', function () use (&$fooSpy, &$barSpy, &$quxSpy) {
+            $fooSpy++;
+            $barSpy++;
+            $quxSpy++;
+        });
+
+        $ee->on('foo', function () use (&$fooSpy) {
+            $fooSpy++;
+        });
+
+        $ee->on('bar', function () use (&$barSpy) {
+            $barSpy++;
+        });
+
+        $ee->emit('foo');
+        $ee->emit('bar');
+        $ee->emit('qux');
+
+        $this->assertEquals(4, $fooSpy);
+        $this->assertEquals(4, $barSpy);
+        $this->assertEquals(3, $quxSpy);
+
+    }
+
 
 }


### PR DESCRIPTION
Hi,

I added some new functionality to the EventEmitter component:

- **Wildcard and namespacing support**. When emitting `foo.bar.baz`, all listeners that have been registered for `foo.bar.baz`, `foo.bar.*`, `foo.*` and `*` will be invoked. 
- **Multi-event support** for `on`, `removeListener` and `removeAllListeners`. All these methods can now be (optionally) called with an array of events:

    `$emitter->on(['foo', 'bar'], $callback);`

**Notes:**
- All the existing unit tests still pass. All new functionality is opt-in only.
- All the new features are fully covered by new unit tests.
- I couldn't update the documentation, since it's not in the repository.
- Unfortunately, implementing wildcard support means that there are now multiple listener lists that get invoked when an event is emitted, so this means that the priority sort has to be made on every `emit()`, thus making the sort flag (currently the first element of each listener list) unusable. This could be worked around by caching the sort order for each event type on `emit`, and invalidating the cache when any new listeners are added that match that specific event type (directly of via wildcard). I will gladly implement this in the future, if wildcard support is something that you want.
