### PR TITLE
New wildcard emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ ChangeLog
 * sabre/event now requires PHP 7. If you need PHP 5.5 support, just keep
   using 3.0.0.
 * PHP 7 type hints are now used everywhere. We're also using strict_types.
+* Support for a new `WildcardEmitter` which allows you to listen for events
+  using the `*` wildcard.
 * Removed deprecated functions `Promise::error` and `Promise::all`. Instead,
   use `Promise::otherwise` and `Promise\all()`.
 * `EventEmitter`, `EventEmitterTrait` and `EventEmitterInterface` are now just
   called `Emitter`, `EmitterTrait`, and `EmitterInterface`.
 * When rejecting Promises, it's now _required_ to use an `Exception` or
   `Throwable`. This makes the typical case simpler and reduces special cases.
-
 
 3.0.0 (2015-11-05)
 ------------------

--- a/lib/WildcardEmitter.php
+++ b/lib/WildcardEmitter.php
@@ -1,0 +1,37 @@
+<?php declare (strict_types=1);
+
+namespace Sabre\Event;
+
+/**
+ * This class is an EventEmitter with support for wildcard event handlers.
+ *
+ * What this means is that you can emit events like this:
+ *
+ *   emit('change:firstName')
+ *
+ * and listen to this event like this:
+ *
+ *   on('change:*')
+ *
+ * A few notes:
+ * 
+ * - Wildcards only work at the end of an event name.
+ * - Currently you can only use 1 wildcard.
+ * - Using ":" as a separator is optional, but it's highly recommended to use
+ *   some kind of separator.
+ *
+ * The WilcardEmitter is a bit slower than the regular Emitter. If you code
+ * must be very high performance, it might be better to try to use the other
+ * emitter. For must usage the difference is negligible though.
+ *
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class WildcardEmitter implements EmitterInterface {
+
+    use WildcardEmitterTrait;
+
+
+
+}

--- a/tests/EmitterTest.php
+++ b/tests/EmitterTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\Event;
 
-class EventEmitterTest extends \PHPUnit_Framework_TestCase {
+class EmitterTest extends \PHPUnit_Framework_TestCase {
 
     function testInit() {
 

--- a/tests/WildcardEmitterTest.php
+++ b/tests/WildcardEmitterTest.php
@@ -1,0 +1,339 @@
+<?php declare (strict_types=1);
+
+namespace Sabre\Event;
+
+class WildcardEmitterTest extends \PHPUnit_Framework_TestCase {
+
+    function testInit() {
+
+        $ee = new WildcardEmitter();
+        $this->assertInstanceOf('Sabre\\Event\\WildcardEmitter', $ee);
+
+    }
+
+    function testListeners() {
+
+        $ee = new WildcardEmitter();
+
+        $callback1 = function() { };
+        $callback2 = function() { };
+        $ee->on('foo', $callback1, 200);
+        $ee->on('foo', $callback2, 100);
+
+        $this->assertEquals([$callback2, $callback1], $ee->listeners('foo'));
+
+    }
+
+    function testWildcardListeners() {
+
+        $ee = new WildcardEmitter();
+
+        $callback1 = function() { };
+        $callback2 = function() { };
+        $ee->on('foo:*', $callback1, 200);
+        $ee->on('foo:bar', $callback2, 100);
+
+        $this->assertEquals([$callback2, $callback1], $ee->listeners('foo:bar'));
+        $this->assertEquals([$callback1], $ee->listeners('foo:baz'));
+
+    }
+
+    /**
+     * @depends testInit
+     */
+    function testHandleEvent() {
+
+        $argResult = null;
+
+        $ee = new WildcardEmitter();
+        $ee->on('foo:*', function($arg) use (&$argResult) {
+
+            $argResult = $arg;
+
+        });
+
+        $this->assertTrue(
+            $ee->emit('foo:BAR', ['bar'])
+        );
+
+        $this->assertEquals('bar', $argResult);
+
+    }
+
+    /**
+     * @depends testHandleEvent
+     */
+    function testCancelEvent() {
+
+        $argResult = 0;
+
+        $ee = new WildcardEmitter();
+        $ee->on('foo:BAR', function($arg) use (&$argResult) {
+
+            $argResult = 1;
+            return false;
+
+        }, 10);
+        $ee->on('foo:*', function($arg) use (&$argResult) {
+
+            $argResult = 2;
+
+        }, 20);
+
+        $this->assertFalse(
+            $ee->emit('foo:BAR', ['bar'])
+        );
+
+        $this->assertEquals(1, $argResult);
+
+        $argResult = 0;
+        $this->assertTrue(
+            $ee->emit('foo:NOTBAR', ['bar'])
+        );
+        $this->assertEquals(2, $argResult);
+
+    }
+
+    /**
+     * @depends testCancelEvent
+     */
+    function testPriority() {
+
+        $argResult = 0;
+
+        $ee = new WildcardEmitter();
+        $ee->on('foo:bar:*', function($arg) use (&$argResult) {
+
+            $argResult = 1;
+            return false;
+
+        });
+        $ee->on('foo:bar:baz', function($arg) use (&$argResult) {
+
+            $argResult = 2;
+            return false;
+
+        }, 1);
+
+        $this->assertFalse(
+            $ee->emit('foo:bar:baz', ['bar'])
+        );
+
+        $this->assertEquals(2, $argResult);
+
+    }
+
+    /**
+     * @depends testPriority
+     */
+    function testPriority2() {
+
+        $result = [];
+        $ee = new WildcardEmitter();
+
+        $ee->on('foo:bar:baz', function() use (&$result) {
+
+            $result[] = 'a';
+
+        }, 200);
+        $ee->on('foo:bar:*', function() use (&$result) {
+
+            $result[] = 'b';
+
+        }, 50);
+        $ee->on('foo:bar:baz', function() use (&$result) {
+
+            $result[] = 'c';
+
+        }, 300);
+        $ee->on('foo:bar:*', function() use (&$result) {
+
+            $result[] = 'd';
+
+        });
+
+        $ee->emit('foo:bar:baz');
+        $this->assertEquals(['b', 'd', 'a', 'c'], $result);
+
+    }
+
+    function testRemoveListener() {
+
+        $result = false;
+
+        $callBack = function() use (&$result) {
+
+            $result = true;
+
+        };
+
+        $ee = new WildcardEmitter();
+
+        $ee->on('foo', $callBack);
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+
+        $result = false;
+
+        $this->assertTrue(
+            $ee->removeListener('foo', $callBack)
+        );
+
+        $ee->emit('foo');
+        $this->assertFalse($result);
+
+    }
+
+    function testRemoveUnknownListener() {
+
+        $result = false;
+
+        $callBack = function() use (&$result) {
+
+            $result = true;
+
+        };
+
+        $ee = new WildcardEmitter();
+
+        $ee->on('foo', $callBack);
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+        $result = false;
+
+        $this->assertFalse($ee->removeListener('bar', $callBack));
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+
+    }
+
+    function testRemoveListenerTwice() {
+
+        $result = false;
+
+        $callBack = function() use (&$result) {
+
+            $result = true;
+
+        };
+
+        $ee = new WildcardEmitter();
+
+        $ee->on('foo', $callBack);
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+        $result = false;
+
+        $this->assertTrue(
+            $ee->removeListener('foo', $callBack)
+        );
+        $this->assertFalse(
+            $ee->removeListener('foo', $callBack)
+        );
+
+        $ee->emit('foo');
+        $this->assertFalse($result);
+
+    }
+
+    function testRemoveAllListeners() {
+
+        $result = false;
+        $callBack = function() use (&$result) {
+
+            $result = true;
+
+        };
+
+        $ee = new WildcardEmitter();
+        $ee->on('foo', $callBack);
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+        $result = false;
+
+        $ee->removeAllListeners('foo');
+
+        $ee->emit('foo');
+        $this->assertFalse($result);
+
+    }
+
+    function testRemoveAllListenersNoArg() {
+
+        $result = false;
+
+        $callBack = function() use (&$result) {
+
+            $result = true;
+
+        };
+
+
+        $ee = new WildcardEmitter();
+        $ee->on('foo', $callBack);
+
+        $ee->emit('foo');
+        $this->assertTrue($result);
+        $result = false;
+
+        $ee->removeAllListeners();
+
+        $ee->emit('foo');
+        $this->assertFalse($result);
+
+    }
+
+    function testOnce() {
+
+        $result = 0;
+
+        $callBack = function() use (&$result) {
+
+            $result++;
+
+        };
+
+        $ee = new WildcardEmitter();
+        $ee->once('foo:*', $callBack);
+
+        $ee->emit('foo:bar');
+        $ee->emit('foo:baz');
+
+        $this->assertEquals(1, $result);
+
+    }
+
+    /**
+     * @depends testCancelEvent
+     */
+    function testPriorityOnce() {
+
+        $argResult = 0;
+
+        $ee = new WildcardEmitter();
+        $ee->once('foo:*', function($arg) use (&$argResult) {
+
+            $argResult = 1;
+            return false;
+
+        });
+        $ee->once('foo:bar', function($arg) use (&$argResult) {
+
+            $argResult = 2;
+            return false;
+
+        }, 1);
+
+        $this->assertFalse(
+            $ee->emit('foo:bar', ['bar'])
+        );
+
+        $this->assertEquals(2, $argResult);
+
+    }
+}


### PR DESCRIPTION
This adds support for a new Wildcard Emitter.

This is an EventEmitter that allows you to listen for events such as:

    method:*

which would be triggered for events such as:

   method:GET
   method:POST

The wildcard emitter is a bit slower than the regular emitter, which is why it's a separate class (and thus an optional feature).

This is inspired by the PR from #33 , but it has a few changes:

1. No multi-level wildcards are allowed
2. The `*` wildcard _must_ be the last character in the event name (`foo:*` is ok but `foo:*:bar` is not).
3. It drops the notion of namespaces. Names and namespace separators are completely arbitrary (`foo*` matches `fooBar`).
4. It has slightly better indexes which hopefully makes it almost just as fast as the regular emitter for common usage.

This will be awesome for sabredav and will solve a few different WTF's. Thanks to @victorstanciu for the inspiration. 