### PR TITLE
Fixed stream_select timeout calculation

### DIFF
--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -282,7 +282,7 @@ class Loop {
         // Add the last timer back to the array.
         if ($timer) {
             $this->timers[] = $timer;
-            return $timer[0] - microtime(true);
+            return max(0, $timer[0] - microtime(true));
         }
 
     }

--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -302,7 +302,7 @@ class Loop {
             $read = $this->readStreams;
             $write = $this->writeStreams;
             $except = null;
-            if (stream_select($read, $write, $except, $timeout ? 0 : null, $timeout ? $timeout : 0)) {
+            if (stream_select($read, $write, $except, ($timeout === null) ? null : 0, $timeout ? $timeout * 1000000 : 0)) {
 
                 // See PHP Bug https://bugs.php.net/bug.php?id=62452
                 // Fixed in PHP7


### PR DESCRIPTION
I fixed the calculation for the stream_select  params.

1. Before the fix, `tv_sec` would be `null` (blocking) for `timeout == 0`.
2. `timeout` is in seconds, so it should be multiplied by 1000000 for `tv_usec`.