### PR TITLE
Fatal TypeError in strict mode when timeout is non-integer

### DIFF
--- a/lib/Loop/Loop.php
+++ b/lib/Loop/Loop.php
@@ -302,7 +302,7 @@ class Loop {
             $read = $this->readStreams;
             $write = $this->writeStreams;
             $except = null;
-            if (stream_select($read, $write, $except, ($timeout === null) ? null : 0, $timeout ? $timeout * 1000000 : 0)) {
+            if (stream_select($read, $write, $except, ($timeout === null) ? null : 0, $timeout ? (int)($timeout * 1000000) : 0)) {
 
                 // See PHP Bug https://bugs.php.net/bug.php?id=62452
                 // Fixed in PHP7


### PR DESCRIPTION
This fixes strict mode error
`PHP Fatal error:  Uncaught TypeError: stream_select() expects parameter 5 to be integer, float given`
when a non-integer timeout is applied to the `stream_select` function