### PR TITLE
Resolve Promise\all immediately for empty array

### DIFF
--- a/lib/Promise/functions.php
+++ b/lib/Promise/functions.php
@@ -33,6 +33,11 @@ function all(array $promises) : Promise {
 
     return new Promise(function($success, $fail) use ($promises) {
 
+        if (empty($promises)) {
+            $success([]);
+            return;
+        }
+
         $successCount = 0;
         $completeResult = [];
 

--- a/tests/Promise/FunctionsTest.php
+++ b/tests/Promise/FunctionsTest.php
@@ -30,6 +30,14 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase {
 
     }
 
+    function testAllEmptyArray() {
+
+        $finalValue = Promise\all([])->wait();
+
+        $this->assertEquals([], $finalValue);
+
+    }
+
     function testAllReject() {
 
         $promise1 = new Promise();


### PR DESCRIPTION
According to [https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/all](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)

`Promise.all()`called with an empty array should resolve synchronously and immediately.

Before this PR it would create a promise that never gets resolved.