### PR TITLE
phpdoc nit on coroutine.php

### DIFF
--- a/lib/coroutine.php
+++ b/lib/coroutine.php
@@ -40,7 +40,7 @@ use Throwable;
  *
  * });
  *
- * @return Sabre\Event\Promise
+ * @return \Sabre\Event\Promise
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License


### PR DESCRIPTION
Some tools may interpret this as `Sabre\Event\Sabre\Event\Promise` if the `@return` is relative.